### PR TITLE
Third umi read

### DIFF
--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,3 +1,4 @@
-sample,fastq_1,fastq_2,read_structure
+sample,fastq_1,fastq_2,read_structure,fastq_umi
 SAMPLE_DUPLEX_SEQ,/path/to/fastq/files/AEG588A1_S1_L002_R1_001.fastq.gz,/path/to/fastq/files/AEG588A1_S1_L002_R2_001.fastq.gz,10M1S+T 10M1S+T
 SAMPLE_SINGLE_UMI,/path/to/fastq/files/AEG588A1_S2_L002_R1_001.fastq.gz,/path/to/fastq/files/AEG588A1_S2_L002_R2_001.fastq.gz,12M+T +T
+SAMPLE_UMI_FASTQ,/path/to/fastq/files/AEG588A1_S2_L002_R1_001.fastq.gz,/path/to/fastq/files/AEG588A1_S2_L002_R3_001.fastq.gz,+T +T +M,/path/to/fastq/files/AEG588A1_S2_L002_R2_001.fastq.gz

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -73,7 +73,9 @@ class RowChecker:
         self._validate_first(row)
         self._validate_second(row)
         self._validate_pair(row)
-        self._seen.add((row[self._sample_col], row[self._first_col], row[self._second_col]))
+        self._seen.add(
+            (row[self._sample_col], row[self._first_col], row[self._second_col])
+        )
         self.modified.append(row)
 
     def _validate_sample(self, row):
@@ -95,14 +97,14 @@ class RowChecker:
     def _validate_pair(self, row):
         """Assert that read pairs have the same file extension. Report pair status."""
         assert (
-            Path(row[self._first_col]).suffixes[-2:] == Path(row[self._second_col]).suffixes[-2:]
+            Path(row[self._first_col]).suffixes[-2:]
+            == Path(row[self._second_col]).suffixes[-2:]
         ), "FASTQ pairs must have the same file extensions."
 
     def _validate_read_structure(self, row):
         """Assert that the second FASTQ entry has the right format if it exists."""
-        assert len(row[self._read_structure_col].split(' ')) == 2, (
-            "Two read structures must be provided."
-        )
+        n_structures = len(row[self._read_structure_col].split(" "))
+        assert 2 <= n_structures <= 3, "Two read structures must be provided."
 
     def _validate_fastq_format(self, filename):
         """Assert that a given filename has one of the expected FASTQ extensions."""
@@ -119,7 +121,9 @@ class RowChecker:
         FASTQ file combination exists.
 
         """
-        assert len(self._seen) == len(self.modified), "The pair of sample name and FASTQ must be unique."
+        assert len(self._seen) == len(
+            self.modified
+        ), "The pair of sample name and FASTQ must be unique."
         if len({pair[0] for pair in self._seen}) < len(self._seen):
             counts = Counter(pair[0] for pair in self._seen)
             seen = Counter()
@@ -192,7 +196,9 @@ def check_samplesheet(file_in, file_out):
         reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
         # Validate the existence of the expected header columns.
         if not required_columns.issubset(reader.fieldnames):
-            logger.critical(f"The sample sheet **must** contain the column headers: {', '.join(required_columns)}.")
+            logger.critical(
+                f"The sample sheet **must** contain the column headers: {', '.join(required_columns)}."
+            )
             sys.exit(1)
         # Validate each row.
         checker = RowChecker()

--- a/modules/local/align_bam/main.nf
+++ b/modules/local/align_bam/main.nf
@@ -52,7 +52,7 @@ process ALIGN_BAM {
 
     """
     # The real path to the FASTA
-    FASTA=`find -L ./ -name "*.amb" | sed 's/.amb//'`
+    FASTA=`find -L ./ -name "*.amb" | sed -r 's/(.64)?.amb//'`
 
     samtools fastq ${samtools_fastq_args} ${unmapped_bam} \\
         | bwa mem ${bwa_args} -t $task.cpus -p -K 150000000 -Y \$FASTA - \\

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -35,7 +35,10 @@ def create_fastq_channel(LinkedHashMap row) {
     if (!file(row.fastq_2).exists()) {
         exit 1, "ERROR: Please check input samplesheet -> Read 2 FastQ file does not exist!\n${row.fastq_2}"
     }
-    if (file(row.fastq_umi).exists()){
+    if (row.fastq_umi){
+        if (!file(row.fastq_umi).exists()) {
+            exit 1, "ERROR: Please check input samplesheet -> UMI FastQ file is specified in samplesheet does not exist!\n${row.fastq_2}"
+        }
         fastq_list = [ file(row.fastq_1), file(row.fastq_2), file(row.fastq_umi) ]
     } else {
         fastq_list = [ file(row.fastq_1), file(row.fastq_2) ]

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -35,6 +35,11 @@ def create_fastq_channel(LinkedHashMap row) {
     if (!file(row.fastq_2).exists()) {
         exit 1, "ERROR: Please check input samplesheet -> Read 2 FastQ file does not exist!\n${row.fastq_2}"
     }
-    fastq_meta = [ meta, [ file(row.fastq_1), file(row.fastq_2) ] ]
+    if (file(row.fastq_umi).exists()){
+        fastq_list = [ file(row.fastq_1), file(row.fastq_2), file(row.fastq_umi) ]
+    } else {
+        fastq_list = [ file(row.fastq_1), file(row.fastq_2) ]
+    }
+    fastq_meta = [ meta, fastq_list ]
     return fastq_meta
 }

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -39,6 +39,9 @@ def create_fastq_channel(LinkedHashMap row) {
         if (!file(row.fastq_umi).exists()) {
             exit 1, "ERROR: Please check input samplesheet -> UMI FastQ file is specified in samplesheet does not exist!\n${row.fastq_2}"
         }
+        if ( params.duplex_seq ) {
+            exit 1, "ERROR: Duplex mode is not compatible with a UMI sequencing file. Please use --duplex_seq false when using a UMI fastq file."
+        }
         fastq_list = [ file(row.fastq_1), file(row.fastq_2), file(row.fastq_umi) ]
     } else {
         fastq_list = [ file(row.fastq_1), file(row.fastq_2) ]


### PR DESCRIPTION
Support for UMI sequences contained in third read, e.g. Nonacus or IDT.

- Adds new column to samplesheet `fastq_umi` for UMI 

Additions:
- Writes software versions in versions.yml

Fixes:
- Catches BWA indexes that include `.64`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
