### PR TITLE
Allow igenomes to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #51](https://github.com/nf-core/fastquorum/pull/51) - Fixes a bug where alignment and filtering where swapped in the phase 2 high-throughput diagrams (@jfy133).
 - [PR #58](https://github.com/nf-core/fastquorum/pull/58) - Prepare genome steps now run only if the corresponding parameters are not passed.
 - [PR #60](https://github.com/nf-core/fastquorum/pull/60) - Enable automatic escalation of memory for FilterConsensusReads.
+- [PR #67](https://github.com/nf-core/fastquorum/pull/67) - Fix setting the parameters from igenomes.
 
 ## [[1.0.0]](https://github.com/nf-core/fastquorum/releases/tag/1.0.0)] -- 2024-05-20
 

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -13,6 +13,8 @@ params {
     genomes {
         'GRCh37' {
             fasta       = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta/genome.fa"
+            fasta_fai   = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta/genome.fa.fai"
+            dict        = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta/genome.dict"
             bwa         = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BWAIndex/version0.6.0/"
             bowtie2     = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/Bowtie2Index/"
             star        = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/STARIndex/"
@@ -26,6 +28,8 @@ params {
         }
         'GRCh38' {
             fasta       = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
+            fasta_fai   = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa.fai"
+            dict        = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.dict"
             bwa         = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BWAIndex/version0.6.0/"
             bowtie2     = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/Bowtie2Index/"
             star        = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/"

--- a/main.nf
+++ b/main.nf
@@ -13,6 +13,18 @@ nextflow.enable.dsl = 2
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    GENOME PARAMETER VALUES
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_fastquorum_pipeline'
+
+params.fasta     = getGenomeAttribute('fasta')
+params.fasta_fai = getGenomeAttribute('fasta_fai')
+params.dict      = getGenomeAttribute('dict')
+params.bwa       = getGenomeAttribute('bwa')
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPORT FUNCTIONS / MODULES / SUBWORKFLOWS / WORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
@@ -20,20 +32,7 @@ nextflow.enable.dsl = 2
 include { FASTQUORUM              } from './workflows/fastquorum'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_fastquorum_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_fastquorum_pipeline'
-include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_fastquorum_pipeline'
 include { PREPARE_GENOME          } from './subworkflows/local/prepare_genome'
-
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    GENOME PARAMETER VALUES
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-params.fasta     = getGenomeAttribute('fasta')
-params.fasta_fai = getGenomeAttribute('fasta_fai')
-params.dict      = getGenomeAttribute('dict')
-params.bwa       = getGenomeAttribute('bwa')
 
 // Initialize fasta file with meta map:
 fasta = params.fasta ? Channel.fromPath(params.fasta).map{ it -> [ [id:it.baseName], it ] }.collect() : Channel.empty()

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,7 +69,7 @@ params {
 
     // Schema validation default options
     validationFailUnrecognisedParams = false
-    validationLenientMode            = true
+    validationLenientMode            = false
     validationSchemaIgnoreParams     = 'genomes,igenomes_base,monochromeLogs,fasta,fasta_fai,bwa,dict'
     validationShowHiddenParams       = false
     validate_params                  = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,10 +16,6 @@ params {
     genome                     = null
     igenomes_base              = 's3://ngi-igenomes/igenomes/'
     igenomes_ignore            = false
-    fasta                      = null
-    bwa                        = null
-    dict                       = null
-    fasta_fai                  = null
     save_reference             = false
 
     // MultiQC options
@@ -73,8 +69,8 @@ params {
 
     // Schema validation default options
     validationFailUnrecognisedParams = false
-    validationLenientMode            = false
-    validationSchemaIgnoreParams     = 'genomes,igenomes_base,monochromeLogs'
+    validationLenientMode            = true
+    validationSchemaIgnoreParams     = 'genomes,igenomes_base,monochromeLogs,fasta,fasta_fai,bwa,dict'
     validationShowHiddenParams       = false
     validate_params                  = true
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -155,6 +155,7 @@
                 "dict": {
                     "type": "string",
                     "fa_icon": "fas fa-file",
+                    "exists": true,
                     "description": "Path to FASTA dictionary file.",
                     "help_text": "If you use AWS iGenomes, this has already been set for you appropriately.\n\n> **NB** If none provided, will be generated automatically from the FASTA reference. Combine with `--save_reference` to save for future runs.",
                     "hidden": true
@@ -162,12 +163,14 @@
                 "fasta_fai": {
                     "type": "string",
                     "fa_icon": "fas fa-file",
+                    "exists": true,
                     "help_text": "If you use AWS iGenomes, this has already been set for you appropriately.\n\n> **NB** If none provided, will be generated automatically from the FASTA reference. Combine with `--save_reference` to save for future runs.",
                     "description": "Path to FASTA reference index."
                 },
                 "bwa": {
                     "type": "string",
                     "fa_icon": "fas fa-copy",
+                    "exists": true,
                     "description": "Path to BWA mem indices.",
                     "help_text": "If you use AWS iGenomes, this has already been set for you appropriately.\n\nIf you wish to recompute indices available on igenomes, set `--bwa false`.\n\n> **NB** If none provided, will be generated automatically from the FASTA reference. Combine with `--save_reference` to save for future runs.",
                     "hidden": true

--- a/subworkflows/local/utils_nfcore_fastquorum_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_fastquorum_pipeline/main.nf
@@ -77,15 +77,6 @@ workflow PIPELINE_INITIALISATION {
     //
     validateInputParameters()
 
-    // Check input path parameters to see if they exist
-    def checkPathParamList = [
-        params.bwa,
-        params.dict,
-        params.fasta,
-        params.fasta_fai
-
-    ]
-
     //
     // Create channel from input file provided through params.input
     //


### PR DESCRIPTION
Fixing the template to allow igenomes to work.
Currently the parameters e.g. `fasta` are being set to a default of `null` in the nextflow.config, which means that they are not able to be overwritten via the script that tries to pull them from the igenomes config.

We might want to add a test profile that uses igenomes; we could swap the test_full to do this.