### PR TITLE
chore: raise minimum version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" && "${{ matrix.NXF_VER }}" != "latest-everything" ]]; then
             echo matrix='["latest-everything"]' | tee -a $GITHUB_OUTPUT
           else
-            echo matrix='["latest-everything", "23.10.0"]' | tee -a $GITHUB_OUTPUT
+            echo matrix='["latest-everything", "23.10.1"]' | tee -a $GITHUB_OUTPUT
           fi
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" && "${{ matrix.NXF_VER }}" != "latest-everything" ]]; then
             echo matrix='["latest-everything"]' | tee -a $GITHUB_OUTPUT
           else
-            echo matrix='["latest-everything", "23.04.0"]' | tee -a $GITHUB_OUTPUT
+            echo matrix='["latest-everything", "23.10.0"]' | tee -a $GITHUB_OUTPUT
           fi
 
   test:


### PR DESCRIPTION
The nf-core template update switches to nf-schema instead of nf-validation which requires nextflow>=23.10.0. Testing on 23.04.0 is expected to fail (and did fail on dev ci checks).

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
