### PR TITLE
fix: align versioning across tests and config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" && "${{ matrix.NXF_VER }}" != "latest-everything" ]]; then
             echo matrix='["latest-everything"]' | tee -a $GITHUB_OUTPUT
           else
-            echo matrix='["latest-everything", "23.10.1"]' | tee -a $GITHUB_OUTPUT
+            echo matrix='["latest-everything", "24.04.2"]' | tee -a $GITHUB_OUTPUT
           fi
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+- [PR #87](https://github.com/nf-core/fastquorum/pull/87) - Raise minimum version to 24.04.2
+- [PR #84](https://github.com/nf-core/fastquorum/pull/84) - Update to nf-core/tools template version 3.0.2
 - [PR #79](https://github.com/nf-core/fastquorum/pull/79) and [PR #80](https://github.com/nf-core/fastquorum/pull/90) - Publish aligned consensus bai file
 
 ## [[1.0.1]](https://github.com/nf-core/fastquorum/releases/tag/1.0.1) -- 2024-09-10

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![GitHub Actions Linting Status](https://github.com/nf-core/fastquorum/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/fastquorum/actions/workflows/linting.yml)[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/fastquorum/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.11267672-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.11267672)
 [![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A523.10.1-23aa62.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A524.04.2-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/nextflow.config
+++ b/nextflow.config
@@ -240,7 +240,7 @@ manifest {
     homePage        = 'https://github.com/nf-core/fastquorum'
     description     = """fgbio Best Practices FASTQ to Consensus Pipeline"""
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=23.10.1'
+    nextflowVersion = '!>=24.04.2'
     version         = '1.0.2dev'
     doi             = '10.5281/zenodo.10456900,10.5281/zenodo.11267672'
 }


### PR DESCRIPTION
Nextflow 24.04.0 is when the `resourceLimits` directive was introduced. Github actions on older versions will fail because they won't respect these resource limits.
https://github.com/nextflow-io/nextflow/blob/0140f954fdcfd0d03c8d568e61b193f0db067bf6/changelog.txt#L252-L257

24.04.2 is the version originally used in the template update PR.
https://github.com/nf-core/fastquorum/blob/5d7af8bd61df3a0e20ab2cd6782530ebeea0aada/nextflow.config#L243C5-L243C20

This PR reverts #86 and further raises the version that was raised in #85 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
