### PR TITLE
fix: allow non-gzipped fastq input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+- [PR #91](https://github.com/nf-core/fastquorum/pull/91) - Allow non-gzipped input fastq files
 - [PR #90](https://github.com/nf-core/fastquorum/pull/90) - Update dependency versions in fastquorum environments
   | Dependency | Previous Version | New Version |
   | ---------- | ---------------- | ----------- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- [PR #91](https://github.com/nf-core/fastquorum/pull/91) - Allow non-gzipped input fastq files
+- [PR #93](https://github.com/nf-core/fastquorum/pull/93) - Allow non-gzipped input fastq files
 - [PR #90](https://github.com/nf-core/fastquorum/pull/90) - Update dependency versions in fastquorum environments
   | Dependency | Previous Version | New Version |
   | ---------- | ---------------- | ----------- |

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -17,15 +17,15 @@
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.f(ast)?q\\.gz$",
-                "errorMessage": "FastQ file for reads 1 must be provided, cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
+                "pattern": "^\\S+\\.f(ast)?q(\\.gz)?$",
+                "errorMessage": "FastQ file for reads 1 must be provided, cannot contain spaces and must have extension '.fq', '.fastq', '.fq.gz' or '.fastq.gz'"
             },
             "fastq_2": {
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.f(ast)?q\\.gz$",
-                "errorMessage": "FastQ file for reads 2 cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
+                "pattern": "^\\S+\\.f(ast)?q(\\.gz)?$",
+                "errorMessage": "FastQ file for reads 2 cannot contain spaces and must have extension '.fq', '.fastq', '.fq.gz' or '.fastq.gz'"
             },
             "fastq_3": {
                 "type": "string",

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -32,14 +32,14 @@
                 "format": "file-path",
                 "exists": true,
                 "pattern": "^\\S+\\.f(ast)?q(\\.gz)?$",
-                "errorMessage": "FastQ file for reads 3 (e.g. index1/i7) cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
+                "errorMessage": "FastQ file for reads 3 (e.g. index1/i7) cannot contain spaces and must have extension '.fq', '.fastq', '.fq.gz' or '.fastq.gz'"
             },
             "fastq_4": {
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
                 "pattern": "^\\S+\\.f(ast)?q(\\.gz)?$",
-                "errorMessage": "FastQ file for reads 4 (e.g. index2/i5) cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
+                "errorMessage": "FastQ file for reads 4 (e.g. index2/i5) cannot contain spaces and must have extension '.fq', '.fastq', '.fq.gz' or '.fastq.gz'"
             },
             "read_structure": {
                 "type": "string",

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -31,14 +31,14 @@
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.f(ast)?q\\.gz$",
+                "pattern": "^\\S+\\.f(ast)?q(\\.gz)?$",
                 "errorMessage": "FastQ file for reads 3 (e.g. index1/i7) cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
             },
             "fastq_4": {
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.f(ast)?q\\.gz$",
+                "pattern": "^\\S+\\.f(ast)?q(\\.gz)?$",
                 "errorMessage": "FastQ file for reads 4 (e.g. index2/i5) cannot contain spaces and must have extension '.fq.gz' or '.fastq.gz'"
             },
             "read_structure": {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,10 +77,10 @@ TREATMENT_REP3,AEG588A6_S6_L004_R1_001.fastq.gz,12M+T +T
 | Column           | Description                                                                                                                                                                            |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sample`         | Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample. Spaces in sample names are automatically converted to underscores (`_`). |
-| `fastq_1`        | Full path to FastQ file for Illumina short reads 1. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
-| `fastq_2`        | Full path to FastQ file for Illumina short reads 2. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
-| `fastq_3`        | Full path to FastQ file for Illumina short reads 3 (e.g. index1/i7). File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                            |
-| `fastq_4`        | Full path to FastQ file for Illumina short reads 4 (e.g. index2/i5). File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                            |
+| `fastq_1`        | Full path to FastQ file for Illumina short reads 1. File has to have the extension ".fastq", ".fq", ".fastq.gz" or ".fq.gz".                                                           |
+| `fastq_2`        | Full path to FastQ file for Illumina short reads 2. File has to have the extension ".fastq", ".fq", ".fastq.gz" or ".fq.gz".                                                           |
+| `fastq_3`        | Full path to FastQ file for Illumina short reads 3 (e.g. index1/i7). File has to have the extension ".fastq", ".fq", ".fastq.gz" or ".fq.gz".                                          |
+| `fastq_4`        | Full path to FastQ file for Illumina short reads 4 (e.g. index2/i5). File has to have the extension ".fastq", ".fq", ".fastq.gz" or ".fq.gz".                                          |
 | `read_structure` | the [`read_structure`][read-structure-link] describes how the bases in a sequencing run should be allocated into logical reads, including the unique molecular index(es)               |
 
 [read-structure-link]: https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures


### PR DESCRIPTION
Closes #91 

This PR allows for the use of `.fastq` or `.fq` files instead of requiring gzipped files.

Tested locally by copying and unzipping the test data for the tiny samplesheet test.
https://raw.githubusercontent.com/nf-core/test-datasets/fastquorum/testdata/samplesheets/samplesheet.tiny.csv

Not sure if we want to add a specific test for non-gzipped input.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] `CHANGELOG.md` is updated.
