### PR TITLE
fix: limit downloads

### DIFF
--- a/.github/workflows/download_pipeline.yml
+++ b/.github/workflows/download_pipeline.yml
@@ -66,7 +66,8 @@ jobs:
           --container-system 'singularity' \
           --container-library "quay.io" -l "docker.io" -l "community.wave.seqera.io" \
           --container-cache-utilisation 'amend' \
-          --download-configuration 'yes'
+          --download-configuration 'yes' \
+          --parallel-downloads 1
 
       - name: Inspect download
         run: tree ./${{ env.REPOTITLE_LOWERCASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[1.0.2]](https://github.com/nf-core/fastquorum/releases/tag/1.0.2) -- 2024-11-15
+## [[1.0.2]](https://github.com/nf-core/fastquorum/releases/tag/1.0.2) -- 2024-11-22
 
 ### Enhancements & fixes
 


### PR DESCRIPTION
There's [a bug in the pipelines download](https://github.com/nf-core/tools/issues/3285) command which is resolved with the limiting to a single concurrent download.

Manual run of the integration test for this branch passes!
https://github.com/nf-core/fastquorum/actions/runs/11903116704/job/33170144108

I also set a planned release date for Friday 2024-11-22. Which will give us time to merge this PR and get a second review.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
