### PR TITLE
feat: validate read structures with the nf-fgbio plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [PR #123](https://github.com/nf-core/fastquorum/pull/123) - Validate read structures with the nf-fgbio plugin
+
 ### Credits
 
 ### Enhancements & fixes

--- a/nextflow.config
+++ b/nextflow.config
@@ -272,8 +272,10 @@ manifest {
 
 // Nextflow plugins
 // nf-schema: validation of pipeline parameters and creation of an input channel from a sample sheet
+// nf-fgbio: validation of read structure(s) passed as parameters
 plugins {
     id 'nf-schema@2.1.1'
+    id 'nf-fgbio@1.0.0'
 }
 
 validation {

--- a/tests/pipeline/tiny.invalid_read_structure.nf.test
+++ b/tests/pipeline/tiny.invalid_read_structure.nf.test
@@ -1,0 +1,29 @@
+nextflow_pipeline {
+
+    name "Test workflow - Invalid read structure"
+    script "main.nf"
+    tag "tiny"
+    tag "pipeline"
+    tag "invalid_read_structure"
+
+    test("bad read structure") {
+        options "-stub"
+        tag "error"
+
+        when {
+            params {
+                input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/fastquorum/testdata/samplesheets/samplesheet.tiny.invalid_read_structure.csv'
+                fasta  = 'https://raw.githubusercontent.com/nf-core/test-datasets/fastquorum/references/chr17.fa'
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.failed },
+                { assert workflow.stdout.any { it.contains("Please check input samplesheet -> Read structure") } }
+            )
+        }
+
+    }
+}


### PR DESCRIPTION
This PR validates the read structures parsed from the sample sheet prior to running any of the tools.  Currently, an invalid read structure would fail when running `fgbio FastqToBam`.  This now fails earlier, in the pipeline initialization.  

The error message includes the following:
1. The error message produced by the `ReadStructure` class (from fgbio) detailing what's invalid
2. A link to read more about read structures
3. A link to a tool to validate read structures.

```console
Please check input samplesheet -> Read structure`10M1sfsf+T` invalid

   Read structure missing length information: 10M1S[F]SF+T

   For more information on read structures, visit: https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures

   Validate your read structures here: https://fulcrumgenomics.github.io/fgbio/validate-read-structure.html 
```

I've tested by supplying a malformed read structure in the sample sheet.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
