### PR TITLE
Ensure the PDF from CollectDuplexSeqMetrics is published

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/fast
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
 - [ ] Make sure your code lints (`nf-core pipelines lint`).
-- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
+- [ ] Ensure the test suite passes (`nf-test test tests/pipeline/*.nf.test --profile test,docker`).
 - [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
 - [ ] Usage Documentation in `docs/usage.md` is updated.
 - [ ] Output Documentation in `docs/output.md` is updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #123](https://github.com/nf-core/fastquorum/pull/123) - Validate read structures with the nf-fgbio plugin
 - [PR #128](https://github.com/nf-core/fastquorum/pull/128) - Add icon image
 - [PR #131](https://github.com/nf-core/fastquorum/pull/131) - Update to nf-core/tools template version 3.3.2
+- [PR #138](https://github.com/nf-core/fastquorum/pull/138) - Ensure the PDF from CollectDuplexSeqMetrics is published
 
 ### Credits
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -98,9 +98,16 @@ process {
 
     withName: COLLECTDUPLEXSEQMETRICS {
         publishDir = [
-            path: { "${params.outdir}/metrics/duplex_seq/${meta.id}" },
-            mode: params.publish_dir_mode,
-            pattern: '*duplex_seq_metrics*.{txt, pdf}',
+            [
+                path: { "${params.outdir}/metrics/duplex_seq/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*duplex_seq_metrics*.txt',
+            ],
+            [
+                path: { "${params.outdir}/metrics/duplex_seq/${meta.id}" },
+                mode: params.publish_dir_mode,
+                pattern: '*duplex_qc.pdf',
+            ]
         ]
     }
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -179,12 +179,12 @@ Collect duplex sequencing specific metrics.
 
 Metrics produced by [`fgbio CollectDuplexSeqMetrics`](http://fulcrumgenomics.github.io/fgbio/tools/latest/CollectDuplexSeqMetrics.html):
 
-- `*.family_sizes.txt*` - metrics on the frequency of different types of families of different sizes
-- `*.duplex_family_sizes.txt*`- metrics on the frequency of duplex tag families by the number of observations from each strand
-- `*.duplex_yield_metrics.txt*`- summary QC metrics produced using 5%, 10%, 15%...100% of the data
-- `*.umi_counts.txt*`- metrics on the frequency of observations of UMIs within reads and tag families
-- `*.duplex_qc.pdf*`- a series of plots generated from the preceding metrics files for visualization
-- `*.duplex_umi_counts.txt*`- (optional) metrics on the frequency of observations of duplex UMIs within reads and tag families. This file is only produced _if_ the `--duplex-umi-counts` option is used as it requires significantly more memory to track all pairs of UMIs seen when a large number of UMI sequences are present.
+- `*.family_sizes.txt` - metrics on the frequency of different types of families of different sizes
+- `*.duplex_family_sizes.txt`- metrics on the frequency of duplex tag families by the number of observations from each strand
+- `*.duplex_yield_metrics.txt`- summary QC metrics produced using 5%, 10%, 15%...100% of the data
+- `*.umi_counts.txt`- metrics on the frequency of observations of UMIs within reads and tag families
+- `*.duplex_qc.pdf`- a series of plots generated from the preceding metrics files for visualization
+- `*.duplex_umi_counts.txt`- (optional) metrics on the frequency of observations of duplex UMIs within reads and tag families. This file is only produced _if_ the `--duplex-umi-counts` option is used as it requires significantly more memory to track all pairs of UMIs seen when a large number of UMI sequences are present.
 
 </details>
 

--- a/modules/local/fgbio/collectduplexseqmetrics/main.nf
+++ b/modules/local/fgbio/collectduplexseqmetrics/main.nf
@@ -12,7 +12,7 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
 
     output:
     tuple val(meta), path("*duplex_seq_metrics*.txt"), emit: metrics
-    tuple val(meta), path("*duplex_seq_metrics*.pdf"), emit: pdf
+    tuple val(meta), path("*duplex_qc.pdf"), emit: pdf
     path "versions.yml", emit: versions
 
     script:

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -11,4 +11,6 @@ multiqc/multiqc_report.html
 **/*fastqc.{html,zip}
 # BAM files include the staged file path of the reference in the sequence dictionary header entry, `UR`, which is not stable across different runs
 **/*.{bam,bai}
+# PDF files from fgbio CollectDuplexSeqMetrics include timestamps and are not stable across different runs
+**/*.duplex_seq_metrics.duplex_qc.pdf
 pipeline_info/*.{html,json,txt,yml}

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -58,6 +58,7 @@
                 "metrics/duplex_seq",
                 "metrics/duplex_seq/SRR6109255",
                 "metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.duplex_family_sizes.txt",
+                "metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.duplex_qc.pdf",
                 "metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.duplex_umi_counts.txt",
                 "metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.duplex_yield_metrics.txt",
                 "metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.family_sizes.txt",
@@ -145,6 +146,7 @@
             [
                 "SRR6109255.grouped-family-sizes.txt:md5,d2b8b8eb6c01a58f9aea6596b44e3735",
                 "SRR6109255.duplex_seq_metrics.duplex_family_sizes.txt:md5,2e699edbafa21fb188a130de3b772bd0",
+                "SRR6109255.duplex_seq_metrics.duplex_qc.pdf:md5,dbe489b6696d1e8dbbf66d4ef3b55efb",
                 "SRR6109255.duplex_seq_metrics.duplex_umi_counts.txt:md5,13d446a97f0ca3fb3f63489b9a4d811e",
                 "SRR6109255.duplex_seq_metrics.duplex_yield_metrics.txt:md5,dc44d3f68aa837f5e1c492c1d107cfda",
                 "SRR6109255.duplex_seq_metrics.family_sizes.txt:md5,1439dc926491ef89f34dc5c56dc61b56",

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -146,7 +146,6 @@
             [
                 "SRR6109255.grouped-family-sizes.txt:md5,d2b8b8eb6c01a58f9aea6596b44e3735",
                 "SRR6109255.duplex_seq_metrics.duplex_family_sizes.txt:md5,2e699edbafa21fb188a130de3b772bd0",
-                "SRR6109255.duplex_seq_metrics.duplex_qc.pdf:md5,dbe489b6696d1e8dbbf66d4ef3b55efb",
                 "SRR6109255.duplex_seq_metrics.duplex_umi_counts.txt:md5,13d446a97f0ca3fb3f63489b9a4d811e",
                 "SRR6109255.duplex_seq_metrics.duplex_yield_metrics.txt:md5,dc44d3f68aa837f5e1c492c1d107cfda",
                 "SRR6109255.duplex_seq_metrics.family_sizes.txt:md5,1439dc926491ef89f34dc5c56dc61b56",

--- a/tests/pipeline/multi_fastq.nf.test
+++ b/tests/pipeline/multi_fastq.nf.test
@@ -25,6 +25,9 @@ nextflow_pipeline {
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_two_fastqs/SRR6109255_two_fastqs.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_three_fastqs/SRR6109255_three_fastqs.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_four_fastqs/SRR6109255_four_fastqs.cons.filtered.bam").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_two_fastqs/SRR6109255_two_fastqs.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_three_fastqs/SRR6109255_three_fastqs.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_four_fastqs/SRR6109255_four_fastqs.duplex_seq_metrics.duplex_qc.pdf").exists() },
                 { assert snapshot(
                     path("$outputDir/grouping/groupreadsbyumi/SRR6109255_two_fastqs/SRR6109255_two_fastqs.grouped-family-sizes.txt"),
                     path("$outputDir/metrics/duplex_seq/SRR6109255_two_fastqs/SRR6109255_two_fastqs.duplex_seq_metrics.family_sizes.txt"),
@@ -58,6 +61,9 @@ nextflow_pipeline {
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_two_fastqs/SRR6109255_two_fastqs.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_three_fastqs/SRR6109255_three_fastqs.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_four_fastqs/SRR6109255_four_fastqs.cons.filtered.bam").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_two_fastqs/SRR6109255_two_fastqs.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_three_fastqs/SRR6109255_three_fastqs.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_four_fastqs/SRR6109255_four_fastqs.duplex_seq_metrics.duplex_qc.pdf").exists() },
                 { assert snapshot(
                     path("$outputDir/grouping/groupreadsbyumi/SRR6109255_two_fastqs/SRR6109255_two_fastqs.grouped-family-sizes.txt"),
                     path("$outputDir/metrics/duplex_seq/SRR6109255_two_fastqs/SRR6109255_two_fastqs.duplex_seq_metrics.family_sizes.txt"),

--- a/tests/pipeline/multi_lanes.nf.test
+++ b/tests/pipeline/multi_lanes.nf.test
@@ -25,6 +25,9 @@ nextflow_pipeline {
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_one_lane/SRR6109255_one_lane.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_two_lanes/SRR6109255_two_lanes.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_three_lanes/SRR6109255_three_lanes.cons.filtered.bam").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_one_lane/SRR6109255_one_lane.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_two_lanes/SRR6109255_two_lanes.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_three_lanes/SRR6109255_three_lanes.duplex_seq_metrics.duplex_qc.pdf").exists() },
                 { assert snapshot(
                     path("$outputDir/grouping/groupreadsbyumi/SRR6109255_one_lane/SRR6109255_one_lane.grouped-family-sizes.txt"),
                     path("$outputDir/metrics/duplex_seq/SRR6109255_one_lane/SRR6109255_one_lane.duplex_seq_metrics.family_sizes.txt"),
@@ -58,6 +61,9 @@ nextflow_pipeline {
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_one_lane/SRR6109255_one_lane.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_two_lanes/SRR6109255_two_lanes.cons.filtered.bam").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255_three_lanes/SRR6109255_three_lanes.cons.filtered.bam").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_one_lane/SRR6109255_one_lane.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_two_lanes/SRR6109255_two_lanes.duplex_seq_metrics.duplex_qc.pdf").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255_three_lanes/SRR6109255_three_lanes.duplex_seq_metrics.duplex_qc.pdf").exists() },
                 { assert snapshot(
                     path("$outputDir/grouping/groupreadsbyumi/SRR6109255_one_lane/SRR6109255_one_lane.grouped-family-sizes.txt"),
                     path("$outputDir/metrics/duplex_seq/SRR6109255_one_lane/SRR6109255_one_lane.duplex_seq_metrics.family_sizes.txt"),

--- a/tests/pipeline/tiny.nf.test
+++ b/tests/pipeline/tiny.nf.test
@@ -23,6 +23,7 @@ nextflow_pipeline {
                 { assert workflow.trace.succeeded().size() == 12 },
                 { assert new File("$outputDir/multiqc/multiqc_report.html").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255/SRR6109255.cons.filtered.bam").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.duplex_qc.pdf").exists() },
                 { assert snapshot(
                     path("$outputDir/grouping/groupreadsbyumi/SRR6109255/SRR6109255.grouped-family-sizes.txt"),
                     path("$outputDir/metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.family_sizes.txt"),
@@ -50,6 +51,7 @@ nextflow_pipeline {
                 { assert workflow.trace.succeeded().size() == 11 },
                 { assert new File("$outputDir/multiqc/multiqc_report.html").exists() },
                 { assert new File("$outputDir/consensus_filtering/filtered/SRR6109255/SRR6109255.cons.filtered.bam").exists() },
+                { assert new File("$outputDir/metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.duplex_qc.pdf").exists() },
                 { assert snapshot(
                     path("$outputDir/grouping/groupreadsbyumi/SRR6109255/SRR6109255.grouped-family-sizes.txt"),
                     path("$outputDir/metrics/duplex_seq/SRR6109255/SRR6109255.duplex_seq_metrics.family_sizes.txt"),


### PR DESCRIPTION
The publish pattern syntax for `CollectDuplexSeqMetrics` erroneously has a space after the `,` so that the pattern will not match correctly on the PDF path. Deleting the space should fix the issue. I also took the time to make tests and update the docs regarding this pipeline output.

---

<!--
# nf-core/fastquorum pull request

Many thanks for contributing to nf-core/fastquorum!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fastquorum/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/fastquorum _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nf-test test tests/pipeline/*.nf.test --profile test,docker`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).