### PR TITLE
chore: switch default branch from master to main

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -1,5 +1,5 @@
 name: nf-core AWS full size tests
-# This workflow is triggered on PRs opened against the main/master branch.
+# This workflow is triggered on PRs opened against the main branch.
 # It can be additionally triggered manually with GitHub actions workflow dispatch button.
 # It runs the -profile 'test_full' on AWS batch
 
@@ -13,8 +13,8 @@ on:
 jobs:
   run-tower:
     name: Run AWS full tests
-    # run only if the PR is approved by at least 2 reviewers and against the master/main branch or manually triggered
-    if: github.repository == 'nf-core/fastquorum' && github.event.review.state == 'approved' && (github.event.pull_request.base.ref == 'master' || github.event.pull_request.base.ref == 'main') || github.event_name == 'workflow_dispatch' || github.event_name == 'release'
+    # run only if the PR is approved by at least 2 reviewers and against the main branch or manually triggered
+    if: github.repository == 'nf-core/fastquorum' && github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'main' || github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Set revision variable

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,17 +1,16 @@
 name: nf-core branch protection
-# This workflow is triggered on PRs to `main`/`master` branch on the repository
-# It fails when someone tries to make a PR against the nf-core `main`/`master` branch instead of `dev`
+# This workflow is triggered on PRs to `main` branch on the repository
+# It fails when someone tries to make a PR against the nf-core `main` branch instead of `dev`
 on:
   pull_request_target:
     branches:
       - main
-      - master
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # PRs to the nf-core repo main/master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
+      # PRs to the nf-core repo main branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == 'nf-core/fastquorum'
         run: |

--- a/.github/workflows/download_pipeline.yml
+++ b/.github/workflows/download_pipeline.yml
@@ -2,7 +2,7 @@ name: Test successful pipeline download with 'nf-core pipelines download'
 
 # Run the workflow when:
 #  - dispatched manually
-#  - when a PR is opened or reopened to main/master branch
+#  - when a PR is opened or reopened to main branch
 #  - the head branch of the pull request is updated, i.e. if fixes for a release are pushed last minute to dev.
 on:
   workflow_dispatch:
@@ -14,7 +14,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 env:
   NXF_ANSI_LOG: false

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -50,7 +50,7 @@ jobs:
           pip install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
 
       - name: Run nf-core pipelines lint
-        if: ${{ github.base_ref != 'master' }}
+        if: ${{ github.base_ref != 'main' }}
         env:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
         run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Run nf-core pipelines lint --release
-        if: ${{ github.base_ref == 'master' }}
+        if: ${{ github.base_ref == 'main' }}
         env:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -70,7 +70,7 @@ jobs:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
         profile: [conda, docker, singularity]
         isMain:
-          - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
+          - ${{ github.base_ref == 'main' }}
         # Exclude conda and singularity on dev
         exclude:
           - isMain: false

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -6,6 +6,8 @@ lint:
   files_unchanged:
     - .gitignore
     - .github/PULL_REQUEST_TEMPLATE.md
+    - .github/workflows/branch.yml
+    - .github/workflows/linting.yml
     - assets/nf-core-fastquorum_logo_light.png
     - docs/images/nf-core-fastquorum_logo_dark.png
     - docs/images/Fulcrum.svg

--- a/nextflow.config
+++ b/nextflow.config
@@ -270,7 +270,7 @@ manifest {
     homePage = 'https://github.com/nf-core/fastquorum'
     description = """fgbio Best Practices FASTQ to Consensus Pipeline"""
     mainScript = 'main.nf'
-    defaultBranch = 'master'
+    defaultBranch = 'main'
     nextflowVersion = '!>=25.04.0'
     version = '1.3.0dev'
     doi = '10.5281/zenodo.10456900,10.5281/zenodo.11267672'

--- a/subworkflows/local/utils_nfcore_fastquorum_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_fastquorum_pipeline/main.nf
@@ -68,7 +68,7 @@ workflow PIPELINE_INITIALISATION {
     https://doi.org/10.1038/s41587-020-0439-x
 
 * Software dependencies
-    https://github.com/nf-core/fastquorum/blob/master/CITATIONS.md
+    https://github.com/nf-core/fastquorum/blob/main/CITATIONS.md
 """
     def command = "nextflow run ${workflow.manifest.name} -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
 


### PR DESCRIPTION
## Summary

- Update `nextflow.config` `defaultBranch` from `master` to `main`
- Update all workflow triggers and `base_ref` checks in `.github/workflows/`
- Update CITATIONS.md link in pipeline help text
- Remove redundant `master` branch entries from workflow triggers (keep only `main`)

External references to other repos (nf-core/configs `master`, nf-core/modules `master`, etc.) are left unchanged.

## Test plan

- [ ] Verify CI triggers correctly on PRs to `main`
- [ ] Verify `nf-core pipelines lint --release` runs on PRs targeting `main`
- [ ] Verify nf-test runs conda/singularity profiles on PRs targeting `main`