### PR TITLE
feat: bring local modules to nf-core 4.0 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #147](https://github.com/nf-core/fastquorum/pull/147) - Add optional `library_id`, `lane`, and `flowcell` samplesheet columns and fix silent pre-merge output overwrites across lanes ([#146](https://github.com/nf-core/fastquorum/issues/146))
 - [PR #150](https://github.com/nf-core/fastquorum/pull/150) - Update to nf-core/tools template version 4.0.2 (raise minimum Nextflow to 25.10.4; remove webhook notifications; move `CONTRIBUTING.md` to `docs/`; switch git hooks to `prek`)
 - [PR #151](https://github.com/nf-core/fastquorum/pull/151) - Update nf-core modules (bwa, fastqc, multiqc, samtools) and remove the `name` field from module `environment.yml` files so the local patches are no longer needed
+- [PR #152](https://github.com/nf-core/fastquorum/pull/152) - Add `environment.yml`, `meta.yml`, and container configs to local modules and recognize the `apptainer` container engine
 
 ### Credits
 

--- a/conf/containers_docker_amd64.config
+++ b/conf/containers_docker_amd64.config
@@ -1,2 +1,12 @@
+process { withName: 'ALIGN_BAM' { container = 'community.wave.seqera.io/library/fgbio_bwa_samtools:04bc9788bca8242c' } }
 process { withName: 'FASTQC' { container = 'community.wave.seqera.io/library/fastqc:0.12.1--5cb1a2fa2f18c7c2' } }
+process { withName: 'FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
+process { withName: 'FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
+process { withName: 'FGBIO_CALLDDUPLEXCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
+process { withName: 'FGBIO_CALLMOLECULARCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
+process { withName: 'FGBIO_COLLECTDUPLEXSEQMETRICS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
+process { withName: 'FGBIO_CORRECTUMIS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
+process { withName: 'FGBIO_FASTQTOBAM' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
+process { withName: 'FGBIO_FILTERCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio_samtools:4f7e98e5f90057a3' } }
+process { withName: 'FGBIO_GROUPREADSBYUMI' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243' } }
 process { withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:1.35--c17fb751507e9dfc' } }

--- a/conf/containers_docker_arm64.config
+++ b/conf/containers_docker_arm64.config
@@ -1,2 +1,12 @@
+process { withName: 'ALIGN_BAM' { container = 'community.wave.seqera.io/library/fgbio_bwa_samtools:fef72c31e6e94318' } }
 process { withName: 'FASTQC' { container = 'community.wave.seqera.io/library/fastqc:0.12.1--e455e32f745abe68' } }
+process { withName: 'FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
+process { withName: 'FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
+process { withName: 'FGBIO_CALLDDUPLEXCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
+process { withName: 'FGBIO_CALLMOLECULARCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
+process { withName: 'FGBIO_COLLECTDUPLEXSEQMETRICS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
+process { withName: 'FGBIO_CORRECTUMIS' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
+process { withName: 'FGBIO_FASTQTOBAM' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
+process { withName: 'FGBIO_FILTERCONSENSUSREADS' { container = 'community.wave.seqera.io/library/fgbio_samtools:9bb31f2fc2d8d1c9' } }
+process { withName: 'FGBIO_GROUPREADSBYUMI' { container = 'community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057' } }
 process { withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:1.35--5c84a5000a226ab5' } }

--- a/conf/containers_singularity_oras_amd64.config
+++ b/conf/containers_singularity_oras_amd64.config
@@ -1,2 +1,12 @@
+process { withName: 'ALIGN_BAM' { container = 'oras://community.wave.seqera.io/library/fgbio_bwa_samtools:ee569c458f161e6b' } }
 process { withName: 'FASTQC' { container = 'oras://community.wave.seqera.io/library/fastqc:0.12.1--5c4bd442468d75dd' } }
+process { withName: 'FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
+process { withName: 'FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
+process { withName: 'FGBIO_CALLDDUPLEXCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
+process { withName: 'FGBIO_CALLMOLECULARCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
+process { withName: 'FGBIO_COLLECTDUPLEXSEQMETRICS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
+process { withName: 'FGBIO_CORRECTUMIS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
+process { withName: 'FGBIO_FASTQTOBAM' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
+process { withName: 'FGBIO_FILTERCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio_samtools:b4fdf6d47eb1eb4a' } }
+process { withName: 'FGBIO_GROUPREADSBYUMI' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b' } }
 process { withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:1.35--c680f2aea25ccec2' } }

--- a/conf/containers_singularity_oras_arm64.config
+++ b/conf/containers_singularity_oras_arm64.config
@@ -1,2 +1,12 @@
+process { withName: 'ALIGN_BAM' { container = 'oras://community.wave.seqera.io/library/fgbio_bwa_samtools:b612d5cd7a652862' } }
 process { withName: 'FASTQC' { container = 'oras://community.wave.seqera.io/library/fastqc:0.12.1--127a87fc06499035' } }
+process { withName: 'FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
+process { withName: 'FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
+process { withName: 'FGBIO_CALLDDUPLEXCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
+process { withName: 'FGBIO_CALLMOLECULARCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
+process { withName: 'FGBIO_COLLECTDUPLEXSEQMETRICS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
+process { withName: 'FGBIO_CORRECTUMIS' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
+process { withName: 'FGBIO_FASTQTOBAM' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
+process { withName: 'FGBIO_FILTERCONSENSUSREADS' { container = 'oras://community.wave.seqera.io/library/fgbio_samtools:bdd8d3bb0416659a' } }
+process { withName: 'FGBIO_GROUPREADSBYUMI' { container = 'oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a' } }
 process { withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:1.35--c0468833d65b2f81' } }

--- a/modules/local/align_bam/environment.yml
+++ b/modules/local/align_bam/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bwa=0.7.18
+  - bioconda::fgbio=2.5.21
+  - bioconda::samtools=1.21

--- a/modules/local/align_bam/main.nf
+++ b/modules/local/align_bam/main.nf
@@ -18,7 +18,9 @@ process ALIGN_BAM {
     output:
     tuple val(meta), path("*.mapped.bam"), emit: bam
     tuple val(meta), path("*.mapped.bam.bai"), emit: bai, optional: true
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('bwa'), eval('bwa 2>&1 | sed -n "s/^Version: //p"'), topic: versions, emit: versions_bwa
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), topic: versions, emit: versions_samtools
 
     when:
     task.ext.when == null || task.ext.when
@@ -86,13 +88,6 @@ process ALIGN_BAM {
             --tags-to-revcomp Consensus \\
             ${fgbio_args} \\
             ${extra_command};
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
     """
 
     stub:
@@ -101,12 +96,5 @@ process ALIGN_BAM {
     """
     touch ${prefix}.mapped.bam
     ${index_command}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/align_bam/main.nf
+++ b/modules/local/align_bam/main.nf
@@ -4,8 +4,8 @@ process ALIGN_BAM {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/22/22fbb5151a7ad857d7a56f28237cdba655110cdd5e685626b0247bd3f04b1b88/data'
-        : 'community.wave.seqera.io/library/bwa_fgbio_samtools:9e8214f5bc9fbfc1'}"
+        ? 'oras://community.wave.seqera.io/library/fgbio_bwa_samtools:ee569c458f161e6b'
+        : 'community.wave.seqera.io/library/fgbio_bwa_samtools:04bc9788bca8242c'}"
 
     input:
     tuple val(meta), path(unmapped_bam)

--- a/modules/local/align_bam/main.nf
+++ b/modules/local/align_bam/main.nf
@@ -3,7 +3,7 @@ process ALIGN_BAM {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio_bwa_samtools:ee569c458f161e6b'
         : 'community.wave.seqera.io/library/fgbio_bwa_samtools:04bc9788bca8242c'}"
 

--- a/modules/local/align_bam/main.nf
+++ b/modules/local/align_bam/main.nf
@@ -2,7 +2,7 @@ process ALIGN_BAM {
     tag "${meta.id}"
     label 'process_high'
 
-    conda "bioconda::fgbio=2.5.21 bioconda::bwa=0.7.18 bioconda::samtools=1.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/22/22fbb5151a7ad857d7a56f28237cdba655110cdd5e685626b0247bd3f04b1b88/data'
         : 'community.wave.seqera.io/library/bwa_fgbio_samtools:9e8214f5bc9fbfc1'}"

--- a/modules/local/align_bam/meta.yml
+++ b/modules/local/align_bam/meta.yml
@@ -78,3 +78,15 @@ output:
 
 authors:
   - "@nh13"
+
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio_bwa_samtools:04bc9788bca8242c
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio_bwa_samtools:fef72c31e6e94318
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio_bwa_samtools:ee569c458f161e6b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio_bwa_samtools:b612d5cd7a652862

--- a/modules/local/align_bam/meta.yml
+++ b/modules/local/align_bam/meta.yml
@@ -1,25 +1,22 @@
-name: fgbio_fastqtobam
+name: align_bam
 description: |
-  Generates an unmapped BAM (or SAM or CRAM) file from fastq files.
+  Aligns reads from an unmapped BAM: streams reads with samtools fastq, aligns
+  with bwa mem, and merges alignment information back into the original records
+  with fgbio ZipperBams, optionally sorting the output with samtools.
 keywords:
+  - bwa
   - fgbio
   - samtools
   - zipperbams
-  - mem
-  - bwa
   - alignment
-  - map
-  - fastq
   - bam
-  - sam
-  -
 tools:
   - bwa:
       description: |
         BWA is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: http://bio-bwa.sourceforge.net/
-      documentation: http://www.htslib.org/doc/samtools.html
+      documentation: http://bio-bwa.sourceforge.net/bwa.shtml
       arxiv: arXiv:1303.3997
       licence: ["GPL-3.0-or-later"]
   - fgbio:
@@ -27,58 +24,68 @@ tools:
       homepage: http://fulcrumgenomics.github.io/fgbio/
       documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
       tool_dev_url: https://github.com/fulcrumgenomics/fgbio
-      doi: ""
       licence: ["MIT"]
   - samtools:
       description: |
         SAMtools is a set of utilities for interacting with and post-processing
-        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
-        These files are generated as output by short read aligners like BWA.
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats.
       homepage: http://www.htslib.org/
-      documentation: hhttp://www.htslib.org/doc/samtools.html
+      documentation: http://www.htslib.org/doc/samtools.html
       doi: 10.1093/bioinformatics/btp352
       licence: ["MIT"]
 input:
   - meta:
       type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - unmapped_bam:
       type: file
-      description: the unmapped BAM/SAM/CRAM file.
-      pattern: "*.{bam,cram,sam}"
+      description: Unmapped BAM whose reads will be aligned and zipped back together
+      pattern: "*.bam"
+  - meta2:
+      type: map
+      description: Groovy Map containing reference information
   - fasta:
       type: file
       description: FASTA reference file
       pattern: "*.{fasta,fa}"
-  - index:
+  - meta3:
+      type: map
+      description: Groovy Map containing reference information
+  - fasta_fai:
       type: file
-      description: BWA genome index files
-      pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
-  - sort:
-      type: bool
-      description: True to sort the output in template-coordinate order, otherwise don't sort
-      pattern: "{true,false}"
-
+      description: FASTA index (.fai) for the reference
+      pattern: "*.fai"
+  - meta4:
+      type: map
+      description: Groovy Map containing reference information
+  - dict:
+      type: file
+      description: Sequence dictionary (.dict) for the reference
+      pattern: "*.dict"
+  - meta5:
+      type: map
+      description: Groovy Map containing reference information
+  - bwa_dir:
+      type: directory
+      description: Directory containing the BWA index files (*.amb, *.ann, *.bwt, *.pac, *.sa)
+  - sort_type:
+      type: string
+      description: |
+        How to sort the aligned output. One of `none` (leave in input order),
+        `coordinate` (coordinate sort and index), or `template-coordinate`.
+      pattern: "{none,coordinate,template-coordinate}"
 output:
   - meta:
       type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - version:
-      type: file
-      description: File containing software version
-      pattern: "*.{version.yml}"
+      description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Mapped bam (unsorted)
-      pattern: "*.{bam}"
-
-authors:
-  - "@nh13"
-
+      description: Aligned BAM with consensus tags reversed/reverse-complemented, optionally sorted
+      pattern: "*.mapped.bam"
+  - bai:
+      type: file
+      description: BAM index, emitted when a coordinate sort with indexing is requested
+      pattern: "*.mapped.bam.bai"
 containers:
   docker:
     linux/amd64:
@@ -90,3 +97,7 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio_bwa_samtools:ee569c458f161e6b
     linux/arm64:
       name: oras://community.wave.seqera.io/library/fgbio_bwa_samtools:b612d5cd7a652862
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/local/fgbio/callandfilterduplexconsensusreads/environment.yml
+++ b/modules/local/fgbio/callandfilterduplexconsensusreads/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
@@ -4,7 +4,7 @@ process FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
@@ -3,7 +3,7 @@ process FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
@@ -17,7 +17,7 @@ process FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS {
 
     output:
     tuple val(meta), path("*.cons.filtered.bam"), emit: bam
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     script:
     def fgbio_call_args = task.ext.fgbio_call_args ?: ''
@@ -64,21 +64,11 @@ process FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS {
         --min-base-quality ${min_baseq} \\
         --max-base-error-rate ${max_base_error_rate} \\
         ${fgbio_filter_args};
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.cons.filtered.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfilterduplexconsensusreads/main.nf
@@ -2,7 +2,7 @@ process FGBIO_CALLANDFILTERDUPLEXCONSENSUSREADS {
     tag "${meta.id}"
     label 'process_high'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/callandfilterduplexconsensusreads/meta.yml
+++ b/modules/local/fgbio/callandfilterduplexconsensusreads/meta.yml
@@ -17,15 +17,32 @@ input:
       description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - bam:
       type: file
-      description: Input BAM file
+      description: Input BAM file with UMI grouped reads, from fgbio's GroupReadsByUmi paired mode
       pattern: "*.bam"
+  - fasta:
+      type: file
+      description: FASTA reference file, used by the filtering step
+      pattern: "*.{fasta,fa}"
+  - fasta_fai:
+      type: file
+      description: FASTA index (.fai) for the reference
+      pattern: "*.fai"
+  - min_reads:
+      type: integer
+      description: The minimum number of reads supporting a consensus base/read
+  - min_baseq:
+      type: integer
+      description: The minimum base quality (used for both calling input and filtering)
+  - max_base_error_rate:
+      type: float
+      description: The maximum raw-read error rate at a consensus base
 output:
   - meta:
       type: map
       description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Output BAM file
+      description: Output BAM file containing filtered duplex consensus reads
       pattern: "*.bam"
 containers:
   docker:
@@ -40,7 +57,5 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
 authors:
   - "@nh13"
-  - "@znorgaard"
 maintainers:
   - "@nh13"
-  - "@znorgaard"

--- a/modules/local/fgbio/callandfilterduplexconsensusreads/meta.yml
+++ b/modules/local/fgbio/callandfilterduplexconsensusreads/meta.yml
@@ -1,0 +1,46 @@
+name: fgbio_callandfilterduplexconsensusreads
+description: Call and filter duplex consensus reads in one step with fgbio
+keywords:
+  - fgbio
+  - duplex
+  - bam
+tools:
+  - fgbio:
+      description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
+  - bam:
+      type: file
+      description: Input BAM file
+      pattern: "*.bam"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bam:
+      type: file
+      description: Output BAM file
+      pattern: "*.bam"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+  - "@znorgaard"
+maintainers:
+  - "@nh13"
+  - "@znorgaard"

--- a/modules/local/fgbio/callandfiltermolecularconsensusreads/environment.yml
+++ b/modules/local/fgbio/callandfiltermolecularconsensusreads/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
@@ -4,7 +4,7 @@ process FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
@@ -2,7 +2,7 @@ process FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS {
     tag "${meta.id}"
     label 'process_high'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
@@ -3,7 +3,7 @@ process FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callandfiltermolecularconsensusreads/main.nf
@@ -17,7 +17,7 @@ process FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS {
 
     output:
     tuple val(meta), path("*.cons.filtered.bam"), emit: bam
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     script:
     def fgbio_call_args = task.ext.fgbio_call_args ?: ''
@@ -64,21 +64,11 @@ process FGBIO_CALLANDFILTERMOLECULARCONSENSUSREADS {
         --min-base-quality ${min_baseq} \\
         --max-base-error-rate ${max_base_error_rate} \\
         ${fgbio_filter_args};
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.cons.filtered.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/callandfiltermolecularconsensusreads/meta.yml
+++ b/modules/local/fgbio/callandfiltermolecularconsensusreads/meta.yml
@@ -17,15 +17,32 @@ input:
       description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - bam:
       type: file
-      description: Input BAM file
+      description: Input BAM file with UMI grouped reads, from fgbio's GroupReadsByUmi
       pattern: "*.bam"
+  - fasta:
+      type: file
+      description: FASTA reference file, used by the filtering step
+      pattern: "*.{fasta,fa}"
+  - fasta_fai:
+      type: file
+      description: FASTA index (.fai) for the reference
+      pattern: "*.fai"
+  - min_reads:
+      type: integer
+      description: The minimum number of reads supporting a consensus base/read
+  - min_baseq:
+      type: integer
+      description: The minimum base quality (used for both calling input and filtering)
+  - max_base_error_rate:
+      type: float
+      description: The maximum raw-read error rate at a consensus base
 output:
   - meta:
       type: map
       description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Output BAM file
+      description: Output BAM file containing filtered single strand consensus reads
       pattern: "*.bam"
 containers:
   docker:
@@ -40,7 +57,5 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
 authors:
   - "@nh13"
-  - "@znorgaard"
 maintainers:
   - "@nh13"
-  - "@znorgaard"

--- a/modules/local/fgbio/callandfiltermolecularconsensusreads/meta.yml
+++ b/modules/local/fgbio/callandfiltermolecularconsensusreads/meta.yml
@@ -1,0 +1,46 @@
+name: fgbio_callandfiltermolecularconsensusreads
+description: Call and filter molecular (single-strand) consensus reads in one step with fgbio
+keywords:
+  - fgbio
+  - consensus
+  - bam
+tools:
+  - fgbio:
+      description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
+  - bam:
+      type: file
+      description: Input BAM file
+      pattern: "*.bam"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bam:
+      type: file
+      description: Output BAM file
+      pattern: "*.bam"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+  - "@znorgaard"
+maintainers:
+  - "@nh13"
+  - "@znorgaard"

--- a/modules/local/fgbio/callduplexconsensusreads/environment.yml
+++ b/modules/local/fgbio/callduplexconsensusreads/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/callduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callduplexconsensusreads/main.nf
@@ -4,7 +4,7 @@ process FGBIO_CALLDDUPLEXCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/callduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callduplexconsensusreads/main.nf
@@ -3,7 +3,7 @@ process FGBIO_CALLDDUPLEXCONSENSUSREADS {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/callduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callduplexconsensusreads/main.nf
@@ -14,7 +14,7 @@ process FGBIO_CALLDDUPLEXCONSENSUSREADS {
 
     output:
     tuple val(meta), path("*.cons.unmapped.bam"), emit: bam
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     script:
     def args = task.ext.args ?: ''
@@ -40,21 +40,11 @@ process FGBIO_CALLDDUPLEXCONSENSUSREADS {
         --min-input-base-quality ${min_baseq} \\
         --threads ${task.cpus} \\
         ${args};
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.cons.unmapped.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/callduplexconsensusreads/main.nf
+++ b/modules/local/fgbio/callduplexconsensusreads/main.nf
@@ -2,7 +2,7 @@ process FGBIO_CALLDDUPLEXCONSENSUSREADS {
     tag "${meta.id}"
     label 'process_low'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/callduplexconsensusreads/meta.yml
+++ b/modules/local/fgbio/callduplexconsensusreads/meta.yml
@@ -17,15 +17,21 @@ input:
       description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - bam:
       type: file
-      description: Input BAM file
+      description: Input BAM file with UMI grouped reads, from fgbio's GroupReadsByUmi paired mode
       pattern: "*.bam"
+  - min_reads:
+      type: integer
+      description: The minimum number of input reads to a consensus read
+  - min_baseq:
+      type: integer
+      description: The minimum input base quality for a base to contribute to a consensus
 output:
   - meta:
       type: map
       description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Output BAM file
+      description: Output BAM file containing duplex consensus reads
       pattern: "*.bam"
 containers:
   docker:
@@ -40,7 +46,5 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
 authors:
   - "@nh13"
-  - "@znorgaard"
 maintainers:
   - "@nh13"
-  - "@znorgaard"

--- a/modules/local/fgbio/callduplexconsensusreads/meta.yml
+++ b/modules/local/fgbio/callduplexconsensusreads/meta.yml
@@ -1,0 +1,46 @@
+name: fgbio_callduplexconsensusreads
+description: Call duplex consensus reads from grouped reads with fgbio
+keywords:
+  - fgbio
+  - duplex
+  - bam
+tools:
+  - fgbio:
+      description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
+  - bam:
+      type: file
+      description: Input BAM file
+      pattern: "*.bam"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bam:
+      type: file
+      description: Output BAM file
+      pattern: "*.bam"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+  - "@znorgaard"
+maintainers:
+  - "@nh13"
+  - "@znorgaard"

--- a/modules/local/fgbio/callmolecularconsensusreads/environment.yml
+++ b/modules/local/fgbio/callmolecularconsensusreads/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callmolecularconsensusreads/main.nf
@@ -2,7 +2,7 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
     tag "${meta.id}"
     label 'process_low'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callmolecularconsensusreads/main.nf
@@ -3,7 +3,7 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callmolecularconsensusreads/main.nf
@@ -14,7 +14,7 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
 
     output:
     tuple val(meta), path("*.cons.unmapped.bam"), emit: bam
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     script:
     def args = task.ext.args ?: ''
@@ -40,21 +40,11 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
         --min-input-base-quality ${min_baseq} \\
         --threads ${task.cpus} \\
         ${args};
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.cons.unmapped.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/local/fgbio/callmolecularconsensusreads/main.nf
@@ -4,7 +4,7 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/callmolecularconsensusreads/meta.yml
+++ b/modules/local/fgbio/callmolecularconsensusreads/meta.yml
@@ -1,0 +1,46 @@
+name: fgbio_callmolecularconsensusreads
+description: Call molecular (single-strand) consensus reads from grouped reads with fgbio
+keywords:
+  - fgbio
+  - consensus
+  - bam
+tools:
+  - fgbio:
+      description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
+  - bam:
+      type: file
+      description: Input BAM file
+      pattern: "*.bam"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bam:
+      type: file
+      description: Output BAM file
+      pattern: "*.bam"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+  - "@znorgaard"
+maintainers:
+  - "@nh13"
+  - "@znorgaard"

--- a/modules/local/fgbio/callmolecularconsensusreads/meta.yml
+++ b/modules/local/fgbio/callmolecularconsensusreads/meta.yml
@@ -17,15 +17,21 @@ input:
       description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - bam:
       type: file
-      description: Input BAM file
+      description: Input BAM file with UMI grouped reads, from fgbio's GroupReadsByUmi
       pattern: "*.bam"
+  - min_reads:
+      type: integer
+      description: The minimum number of input reads to a consensus read
+  - min_baseq:
+      type: integer
+      description: The minimum input base quality for a base to contribute to a consensus
 output:
   - meta:
       type: map
       description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Output BAM file
+      description: Output BAM file containing single strand consensus reads
       pattern: "*.bam"
 containers:
   docker:
@@ -40,7 +46,5 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
 authors:
   - "@nh13"
-  - "@znorgaard"
 maintainers:
   - "@nh13"
-  - "@znorgaard"

--- a/modules/local/fgbio/collectduplexseqmetrics/environment.yml
+++ b/modules/local/fgbio/collectduplexseqmetrics/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/collectduplexseqmetrics/main.nf
+++ b/modules/local/fgbio/collectduplexseqmetrics/main.nf
@@ -2,7 +2,7 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
     tag "${meta.id}"
     label 'process_low'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/collectduplexseqmetrics/main.nf
+++ b/modules/local/fgbio/collectduplexseqmetrics/main.nf
@@ -3,7 +3,7 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/collectduplexseqmetrics/main.nf
+++ b/modules/local/fgbio/collectduplexseqmetrics/main.nf
@@ -4,7 +4,7 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/collectduplexseqmetrics/main.nf
+++ b/modules/local/fgbio/collectduplexseqmetrics/main.nf
@@ -13,7 +13,7 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
     output:
     tuple val(meta), path("*duplex_seq_metrics*.txt"), emit: metrics
     tuple val(meta), path("*duplex_qc.pdf"), emit: pdf
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     script:
     def args = task.ext.args ?: ''
@@ -36,11 +36,6 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
         --output ${prefix}.duplex_seq_metrics \\
         --duplex-umi-counts=true \\
         ${args};
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
@@ -52,10 +47,5 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
     touch ${prefix}.duplex_seq_metrics.family_sizes.txt
     touch ${prefix}.duplex_seq_metrics.umi_counts.txt
     touch ${prefix}.duplex_seq_metrics.duplex_qc.pdf
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/collectduplexseqmetrics/meta.yml
+++ b/modules/local/fgbio/collectduplexseqmetrics/meta.yml
@@ -1,0 +1,46 @@
+name: fgbio_collectduplexseqmetrics
+description: Collect duplex-sequencing QC metrics with fgbio
+keywords:
+  - fgbio
+  - metrics
+  - bam
+tools:
+  - fgbio:
+      description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
+  - bam:
+      type: file
+      description: Input BAM file
+      pattern: "*.bam"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bam:
+      type: file
+      description: Output BAM file
+      pattern: "*.bam"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+  - "@znorgaard"
+maintainers:
+  - "@nh13"
+  - "@znorgaard"

--- a/modules/local/fgbio/collectduplexseqmetrics/meta.yml
+++ b/modules/local/fgbio/collectduplexseqmetrics/meta.yml
@@ -17,16 +17,26 @@ input:
       description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - bam:
       type: file
-      description: Input BAM file
+      description: BAM file with MI tags present and in Template Coordinate sort order, typically the output of fgbio GroupReadsByUMI in paired mode
       pattern: "*.bam"
 output:
   - meta:
       type: map
       description: Groovy Map containing sample information
-  - bam:
+  - metrics:
       type: file
-      description: Output BAM file
-      pattern: "*.bam"
+      description: |
+        Duplex sequencing QC metric files, sharing the output prefix:
+          `*.family_sizes.txt` (frequency of tag families by size),
+          `*.duplex_family_sizes.txt` (frequency of duplex tag families by observations from each strand),
+          `*.duplex_yield_metrics.txt` (summary QC metrics computed across 5%..100% subsamples of the data),
+          `*.umi_counts.txt` (frequency of UMI observations within reads and tag families), and
+          `*.duplex_umi_counts.txt` (frequency of duplex UMI observations; emitted because `--duplex-umi-counts=true`).
+      pattern: "*duplex_seq_metrics*.txt"
+  - pdf:
+      type: file
+      description: PDF of plots generated from the duplex sequencing QC metrics files
+      pattern: "*duplex_qc.pdf"
 containers:
   docker:
     linux/amd64:
@@ -40,7 +50,5 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
 authors:
   - "@nh13"
-  - "@znorgaard"
 maintainers:
   - "@nh13"
-  - "@znorgaard"

--- a/modules/local/fgbio/correctumis/environment.yml
+++ b/modules/local/fgbio/correctumis/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/correctumis/main.nf
+++ b/modules/local/fgbio/correctumis/main.nf
@@ -3,7 +3,7 @@ process FGBIO_CORRECTUMIS {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/correctumis/main.nf
+++ b/modules/local/fgbio/correctumis/main.nf
@@ -16,7 +16,7 @@ process FGBIO_CORRECTUMIS {
     tuple val(meta), path("*.corrected.bam"), emit: bam
     tuple val(meta), path("*.rejected.bam"), emit: rejects
     tuple val(meta), path("*.correct-umis-metrics.txt"), emit: metrics
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     when:
     task.ext.when == null || task.ext.when
@@ -46,11 +46,6 @@ process FGBIO_CORRECTUMIS {
         --min-distance ${min_distance} \\
         --umi-files ${umi_file} \\
         ${args}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
@@ -59,10 +54,5 @@ process FGBIO_CORRECTUMIS {
     touch ${prefix}.corrected.bam
     touch ${prefix}.rejected.bam
     touch ${prefix}.correct-umis-metrics.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/correctumis/main.nf
+++ b/modules/local/fgbio/correctumis/main.nf
@@ -4,7 +4,7 @@ process FGBIO_CORRECTUMIS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/correctumis/main.nf
+++ b/modules/local/fgbio/correctumis/main.nf
@@ -2,7 +2,7 @@ process FGBIO_CORRECTUMIS {
     tag "${meta.id}"
     label 'process_low'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/correctumis/meta.yml
+++ b/modules/local/fgbio/correctumis/meta.yml
@@ -1,0 +1,46 @@
+name: fgbio_correctumis
+description: Correct UMIs against a known set of expected UMIs with fgbio
+keywords:
+  - fgbio
+  - umi
+  - bam
+tools:
+  - fgbio:
+      description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
+  - bam:
+      type: file
+      description: Input BAM file
+      pattern: "*.bam"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bam:
+      type: file
+      description: Output BAM file
+      pattern: "*.bam"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+  - "@znorgaard"
+maintainers:
+  - "@nh13"
+  - "@znorgaard"

--- a/modules/local/fgbio/correctumis/meta.yml
+++ b/modules/local/fgbio/correctumis/meta.yml
@@ -17,16 +17,34 @@ input:
       description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - bam:
       type: file
-      description: Input BAM file
+      description: Input BAM file with UMIs in the RX tag
       pattern: "*.bam"
+  - umi_file:
+      type: file
+      description: File listing the expected UMI sequences, one per line
+      pattern: "*.{txt,fasta,fa}"
+  - max_mismatches:
+      type: integer
+      description: The maximum number of mismatches between a read's UMI and an expected UMI
+  - min_distance:
+      type: integer
+      description: The minimum edit distance to the second-best expected UMI to accept a correction
 output:
   - meta:
       type: map
       description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Output BAM file
-      pattern: "*.bam"
+      description: BAM with corrected UMIs (reads whose UMIs were matched/corrected)
+      pattern: "*.corrected.bam"
+  - rejects:
+      type: file
+      description: BAM containing reads whose UMIs could not be matched to an expected UMI
+      pattern: "*.rejected.bam"
+  - metrics:
+      type: file
+      description: Metrics describing the frequency with which each expected UMI was observed
+      pattern: "*.correct-umis-metrics.txt"
 containers:
   docker:
     linux/amd64:
@@ -40,7 +58,5 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
 authors:
   - "@nh13"
-  - "@znorgaard"
 maintainers:
   - "@nh13"
-  - "@znorgaard"

--- a/modules/local/fgbio/fastqtobam/environment.yml
+++ b/modules/local/fgbio/fastqtobam/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/fastqtobam/main.nf
+++ b/modules/local/fgbio/fastqtobam/main.nf
@@ -3,7 +3,7 @@ process FGBIO_FASTQTOBAM {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/fastqtobam/main.nf
+++ b/modules/local/fgbio/fastqtobam/main.nf
@@ -4,7 +4,7 @@ process FGBIO_FASTQTOBAM {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/fastqtobam/main.nf
+++ b/modules/local/fgbio/fastqtobam/main.nf
@@ -12,7 +12,7 @@ process FGBIO_FASTQTOBAM {
 
     output:
     tuple val(meta), path("*.unmapped.bam"), emit: bam
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     when:
     task.ext.when == null || task.ext.when
@@ -42,21 +42,11 @@ process FGBIO_FASTQTOBAM {
         --sample ${meta.sample} \\
         --library ${meta.id} \\
         ${args}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.unmapped.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/fastqtobam/main.nf
+++ b/modules/local/fgbio/fastqtobam/main.nf
@@ -2,7 +2,7 @@ process FGBIO_FASTQTOBAM {
     tag "${meta.id}"
     label 'process_low'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/fastqtobam/meta.yml
+++ b/modules/local/fgbio/fastqtobam/meta.yml
@@ -1,56 +1,40 @@
 name: fgbio_fastqtobam
 description: |
-  Generates an unmapped BAM (or SAM or CRAM) file from fastq files.
+  Generates an unmapped BAM file from FASTQ files, extracting any UMIs into the
+  RX tag according to the read structure.
 keywords:
   - fastqtobam
   - fgbio
+  - umi
+  - fastq
+  - bam
 tools:
   - fgbio:
       description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
       homepage: http://fulcrumgenomics.github.io/fgbio/
       documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
       tool_dev_url: https://github.com/fulcrumgenomics/fgbio
-      doi: ""
       licence: ["MIT"]
-
 input:
   - meta:
       type: map
       description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
+        Groovy Map containing sample information. Must include `id`, `sample`, and
+        `read_structure`, e.g. `[ id:'lib1', sample:'sample1', read_structure:'+T +T' ]`.
+        The read structure should describe each FASTQ; if a read has no UMI use `+T`
+        (template of any length). See https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures
   - fastqs:
       type: file
-      description: one or more FASTQs to convert to BAM.
-      pattern: "*.{fastq.gz}"
-  - read_structure:
-      type: string
-      description: |
-        A read structure should always be provided for each of the FASTQ files.
-        If single end, the string will contain only one structure (i.e. "2M11S+T"), if paired-end the string
-        will contain two structures separated by a blank space (i.e. "2M11S+T 2M11S+T").
-        If the read does not contain any UMI, the structure will be +T (i.e. only template of any length).
-        Index reads may also be given if useful, see:
-        https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures
-
+      description: One or more FASTQs to convert to BAM
+      pattern: "*.{fastq.gz,fq.gz}"
 output:
   - meta:
       type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - version:
-      type: file
-      description: File containing software version
-      pattern: "*.{version.yml}"
+      description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Converted, unsorted BAM file with RX tag reporting UMI sequence (if any)
-      pattern: "*.{bam}"
-
-authors:
-  - "@nh13"
-
+      description: Unmapped BAM with the UMI sequence (if any) in the RX tag
+      pattern: "*.unmapped.bam"
 containers:
   docker:
     linux/amd64:
@@ -62,3 +46,7 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
     linux/arm64:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/local/fgbio/fastqtobam/meta.yml
+++ b/modules/local/fgbio/fastqtobam/meta.yml
@@ -50,3 +50,15 @@ output:
 
 authors:
   - "@nh13"
+
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a

--- a/modules/local/fgbio/filterconsensusreads/environment.yml
+++ b/modules/local/fgbio/filterconsensusreads/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21
+  - bioconda::samtools=1.21

--- a/modules/local/fgbio/filterconsensusreads/main.nf
+++ b/modules/local/fgbio/filterconsensusreads/main.nf
@@ -18,7 +18,7 @@ process FGBIO_FILTERCONSENSUSREADS {
     output:
     tuple val(meta), path("*.cons.filtered.bam"), emit: bam
     tuple val(meta), path("*.cons.filtered.bam.bai"), emit: bai
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     script:
     def fgbio_args = task.ext.fgbio_args ?: ''
@@ -50,11 +50,6 @@ process FGBIO_FILTERCONSENSUSREADS {
         -o ${prefix}.cons.filtered.bam##idx##${prefix}.cons.filtered.bam.bai \\
         --write-index \\
         ${samtools_args};
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
@@ -62,10 +57,5 @@ process FGBIO_FILTERCONSENSUSREADS {
     """
     touch ${prefix}.cons.filtered.bam
     touch ${prefix}.cons.filtered.bam.bai
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/filterconsensusreads/main.nf
+++ b/modules/local/fgbio/filterconsensusreads/main.nf
@@ -3,7 +3,7 @@ process FGBIO_FILTERCONSENSUSREADS {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio_samtools:b4fdf6d47eb1eb4a'
         : 'community.wave.seqera.io/library/fgbio_samtools:4f7e98e5f90057a3'}"
 

--- a/modules/local/fgbio/filterconsensusreads/main.nf
+++ b/modules/local/fgbio/filterconsensusreads/main.nf
@@ -4,7 +4,7 @@ process FGBIO_FILTERCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fe/fe831f4de10a655551c14ef3d113eac2aec186b73ffffa686691d7471522fef7/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio_samtools:b4fdf6d47eb1eb4a'
         : 'community.wave.seqera.io/library/fgbio_samtools:4f7e98e5f90057a3'}"
 
 

--- a/modules/local/fgbio/filterconsensusreads/main.nf
+++ b/modules/local/fgbio/filterconsensusreads/main.nf
@@ -2,7 +2,7 @@ process FGBIO_FILTERCONSENSUSREADS {
     tag "${meta.id}"
     label 'process_low'
 
-    conda "bioconda::fgbio=2.5.21 bioconda::samtools=1.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fe/fe831f4de10a655551c14ef3d113eac2aec186b73ffffa686691d7471522fef7/data'
         : 'community.wave.seqera.io/library/fgbio_samtools:4f7e98e5f90057a3'}"

--- a/modules/local/fgbio/filterconsensusreads/main.nf
+++ b/modules/local/fgbio/filterconsensusreads/main.nf
@@ -19,6 +19,7 @@ process FGBIO_FILTERCONSENSUSREADS {
     tuple val(meta), path("*.cons.filtered.bam"), emit: bam
     tuple val(meta), path("*.cons.filtered.bam.bai"), emit: bai
     tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), topic: versions, emit: versions_samtools
 
     script:
     def fgbio_args = task.ext.fgbio_args ?: ''

--- a/modules/local/fgbio/filterconsensusreads/meta.yml
+++ b/modules/local/fgbio/filterconsensusreads/meta.yml
@@ -1,0 +1,52 @@
+name: fgbio_filterconsensusreads
+description: Filter consensus reads with fgbio
+keywords:
+  - fgbio
+  - consensus
+  - bam
+tools:
+  - fgbio:
+      description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
+      homepage: http://fulcrumgenomics.github.io/fgbio/
+      documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
+      tool_dev_url: https://github.com/fulcrumgenomics/fgbio
+      licence: ["MIT"]
+  - samtools:
+      description: Tools for manipulating next-generation sequencing data
+      homepage: http://www.htslib.org/
+      documentation: http://www.htslib.org/doc/samtools.html
+      tool_dev_url: https://github.com/samtools/samtools
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
+  - bam:
+      type: file
+      description: Input BAM file
+      pattern: "*.bam"
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - bam:
+      type: file
+      description: Output BAM file
+      pattern: "*.bam"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio_samtools:4f7e98e5f90057a3
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio_samtools:9bb31f2fc2d8d1c9
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio_samtools:b4fdf6d47eb1eb4a
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio_samtools:bdd8d3bb0416659a
+authors:
+  - "@nh13"
+  - "@znorgaard"
+maintainers:
+  - "@nh13"
+  - "@znorgaard"

--- a/modules/local/fgbio/filterconsensusreads/meta.yml
+++ b/modules/local/fgbio/filterconsensusreads/meta.yml
@@ -23,16 +23,36 @@ input:
       description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - bam:
       type: file
-      description: Input BAM file
+      description: Input BAM file containing consensus reads
       pattern: "*.bam"
+  - genome:
+      type: map
+      description: Groovy Map containing reference information
+  - fasta:
+      type: file
+      description: FASTA reference file
+      pattern: "*.{fasta,fa}"
+  - min_reads:
+      type: integer
+      description: The minimum number of reads supporting a consensus base/read
+  - min_baseq:
+      type: integer
+      description: The minimum consensus base quality to retain a base
+  - max_base_error_rate:
+      type: float
+      description: The maximum raw-read error rate at a consensus base
 output:
   - meta:
       type: map
       description: Groovy Map containing sample information
   - bam:
       type: file
-      description: Output BAM file
-      pattern: "*.bam"
+      description: Coordinate-sorted BAM of filtered consensus reads
+      pattern: "*.cons.filtered.bam"
+  - bai:
+      type: file
+      description: Index for the filtered consensus BAM
+      pattern: "*.cons.filtered.bam.bai"
 containers:
   docker:
     linux/amd64:
@@ -46,7 +66,5 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio_samtools:bdd8d3bb0416659a
 authors:
   - "@nh13"
-  - "@znorgaard"
 maintainers:
   - "@nh13"
-  - "@znorgaard"

--- a/modules/local/fgbio/groupreadsbyumi/environment.yml
+++ b/modules/local/fgbio/groupreadsbyumi/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fgbio=2.5.21

--- a/modules/local/fgbio/groupreadsbyumi/main.nf
+++ b/modules/local/fgbio/groupreadsbyumi/main.nf
@@ -16,7 +16,7 @@ process FGBIO_GROUPREADSBYUMI {
     tuple val(meta), path("*.grouped.bam"), emit: bam
     tuple val(meta), path("*.grouped-family-sizes.txt"), emit: histogram
     tuple val(meta), path("*.grouped-read-metrics.txt"), emit: read_metrics
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('fgbio'), eval("fgbio --version 2>&1 | tr -d '[:cntrl:]' | sed -e 's/^.*Version: //;s/\\[.*\$//'"), topic: versions, emit: versions_fgbio
 
     script:
     def args = task.ext.args ?: ''
@@ -43,11 +43,6 @@ process FGBIO_GROUPREADSBYUMI {
         --family-size-histogram ${prefix}.grouped-family-sizes.txt \\
         --grouping-metrics ${prefix}.grouped-read-metrics.txt \\
         ${args}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 
     stub:
@@ -56,10 +51,5 @@ process FGBIO_GROUPREADSBYUMI {
     touch ${prefix}.grouped.bam
     touch ${prefix}.grouped-family-sizes.txt
     touch ${prefix}.grouped-read-metrics.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fgbio: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/fgbio/groupreadsbyumi/main.nf
+++ b/modules/local/fgbio/groupreadsbyumi/main.nf
@@ -2,7 +2,7 @@ process FGBIO_GROUPREADSBYUMI {
     tag "${meta.id}"
     label 'process_low'
 
-    conda "bioconda::fgbio=2.5.21"
+    conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"

--- a/modules/local/fgbio/groupreadsbyumi/main.nf
+++ b/modules/local/fgbio/groupreadsbyumi/main.nf
@@ -4,7 +4,7 @@ process FGBIO_GROUPREADSBYUMI {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/b4047e3e517b57fae311eab139a12f0887d898b7da5fceeb2a1029c73b9e3904/data'
+        ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 
     input:

--- a/modules/local/fgbio/groupreadsbyumi/main.nf
+++ b/modules/local/fgbio/groupreadsbyumi/main.nf
@@ -3,7 +3,7 @@ process FGBIO_GROUPREADSBYUMI {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b'
         : 'community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243'}"
 

--- a/modules/local/fgbio/groupreadsbyumi/meta.yml
+++ b/modules/local/fgbio/groupreadsbyumi/meta.yml
@@ -1,62 +1,50 @@
 name: fgbio_groupreadsbyumi
 description: |
-  Groups reads together that appear to have come from the same original molecule.
+  Groups reads together that appear to have come from the same original molecule,
+  based on their UMIs and mapping positions.
 keywords:
-  - UMI
+  - umi
   - groupreads
   - fgbio
+  - bam
 tools:
   - fgbio:
       description: A set of tools for working with genomic and high throughput sequencing data, including UMIs
       homepage: http://fulcrumgenomics.github.io/fgbio/
       documentation: http://fulcrumgenomics.github.io/fgbio/tools/latest/
       tool_dev_url: https://github.com/fulcrumgenomics/fgbio
-      doi: ""
       licence: ["MIT"]
-
 input:
   - meta:
       type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
+      description: Groovy Map containing sample information, e.g. `[ id:'sample1' ]`
   - mapped_bam:
       type: file
-      description: |
-        BAM file.
+      description: Mapped BAM with UMIs present in the RX tag
       pattern: "*.bam"
   - strategy:
-      type: value
+      type: string
       description: |
-        The UMI assignment strategy.
-        Must be chosen among: Identity, Edit, Adjacency, Paired.
-  - edit:
-      type: value
-      description: |
-        The allowable number of edits between UMIs
-
+        The UMI assignment strategy, one of: Identity, Edit, Adjacency, Paired.
+  - edits:
+      type: integer
+      description: The allowable number of edits between UMIs
 output:
   - meta:
       type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      description: Groovy Map containing sample information
   - bam:
       type: file
-      description: UMI-grouped BAM
+      description: UMI-grouped BAM with the MI tag assigned
       pattern: "*.grouped.bam"
   - histogram:
       type: file
-      description: A text file containing the tag family size counts
+      description: Text file containing the tag family size counts
       pattern: "*.grouped-family-sizes.txt"
-
-authors:
-  - "@lescai"
-
+  - read_metrics:
+      type: file
+      description: Text file containing per-read grouping metrics
+      pattern: "*.grouped-read-metrics.txt"
 containers:
   docker:
     linux/amd64:
@@ -68,3 +56,7 @@ containers:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
     linux/arm64:
       name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/local/fgbio/groupreadsbyumi/meta.yml
+++ b/modules/local/fgbio/groupreadsbyumi/meta.yml
@@ -56,3 +56,15 @@ output:
 
 authors:
   - "@lescai"
+
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--368dab1b4f308243
+    linux/arm64:
+      name: community.wave.seqera.io/library/fgbio:2.5.21--561e291fd356d057
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--1afc8befe439164b
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/fgbio:2.5.21--61a21b7736fed99a

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev",
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev",
             [
                 "consensus_calling",
                 "consensus_calling/called",
@@ -122,7 +122,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-06-05T14:45:31.702756",
+        "timestamp": "2026-06-12T11:11:21.633986",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/library_id.nf.test.snap
+++ b/tests/pipeline/library_id.nf.test.snap
@@ -1,9 +1,9 @@
 {
     "library_id_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T14:47:55.272126",
+        "timestamp": "2026-06-12T11:13:48.465033",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/mixed_umis.nf.test.snap
+++ b/tests/pipeline/mixed_umis.nf.test.snap
@@ -1,9 +1,9 @@
 {
     "mixed_umis_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T14:52:44.927841",
+        "timestamp": "2026-06-12T11:18:43.7987",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/multi_fastq.nf.test.snap
+++ b/tests/pipeline/multi_fastq.nf.test.snap
@@ -26,9 +26,9 @@
     },
     "multi_fastq_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T14:55:21.115395",
+        "timestamp": "2026-06-12T11:21:25.525892",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/multi_lanes.nf.test.snap
+++ b/tests/pipeline/multi_lanes.nf.test.snap
@@ -1,9 +1,9 @@
 {
     "multi_lanes_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; MERGE_BAM:samtools=1.23.1; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; MERGE_BAM:samtools=1.23.1; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T15:00:40.954487",
+        "timestamp": "2026-06-12T11:26:53.855086",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/nonrandom.nf.test.snap
+++ b/tests/pipeline/nonrandom.nf.test.snap
@@ -12,9 +12,9 @@
     },
     "nonrandom_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T15:07:52.877118",
+        "timestamp": "2026-06-12T11:34:22.930195",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/nonrandom_multi_lanes.nf.test.snap
+++ b/tests/pipeline/nonrandom_multi_lanes.nf.test.snap
@@ -1,9 +1,9 @@
 {
     "nonrandom_multi_lanes_metadata_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; MERGE_BAM:samtools=1.23.1; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; MERGE_BAM:samtools=1.23.1; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T15:14:55.401887",
+        "timestamp": "2026-06-12T11:41:29.414976",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -11,9 +11,9 @@
     },
     "nonrandom_multi_lanes_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; MERGE_BAM:samtools=1.23.1; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; CORRECTUMIS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; MERGE_BAM:samtools=1.23.1; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T15:12:25.448298",
+        "timestamp": "2026-06-12T11:38:59.879691",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/single_fastq.nf.test.snap
+++ b/tests/pipeline/single_fastq.nf.test.snap
@@ -21,9 +21,9 @@
     },
     "single_fastq_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLMOLECULARCONSENSUSREADS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLMOLECULARCONSENSUSREADS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-05T15:18:26.075556",
+        "timestamp": "2026-06-12T11:43:44.338278",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/tests/pipeline/tiny.nf.test.snap
+++ b/tests/pipeline/tiny.nf.test.snap
@@ -1,9 +1,9 @@
 {
     "tiny_rd_software_versions": {
         "content": [
-            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
+            "ALIGN_CONSENSUS_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; ALIGN_RAW_BAM:bwa=0.7.18-r1243-dirty,fgbio=2.5.21,samtools=1.21; BWAMEM1_INDEX:bwa=0.7.19-r1273; CALLDDUPLEXCONSENSUSREADS:fgbio=2.5.21; COLLECTDUPLEXSEQMETRICS:fgbio=2.5.21; FASTQC:fastqc=0.12.1; FASTQTOBAM:fgbio=2.5.21; FILTERCONSENSUSREADS:fgbio=2.5.21,samtools=1.21; GROUPREADSBYUMI:fgbio=2.5.21; SAMTOOLS_DICT:samtools=1.23.1; SAMTOOLS_FAIDX:samtools=1.23.1; Workflow:nf-core/fastquorum=v1.3.0dev"
         ],
-        "timestamp": "2026-06-12T16:26:07.226149",
+        "timestamp": "2026-06-15T17:01:29.965633",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/workflows/fastquorum.nf
+++ b/workflows/fastquorum.nf
@@ -56,7 +56,6 @@ workflow FASTQUORUM {
     // MODULE: Run fgbio FastqToBam
     //
     FASTQTOBAM(ch_samplesheet)
-    ch_versions = ch_versions.mix(FASTQTOBAM.out.versions.first())
 
     //
     // MODULE: Run fgbio CorrectUmis (for non-random UMIs)
@@ -83,7 +82,6 @@ workflow FASTQUORUM {
         params.correct_umis_max_mismatches,
         params.correct_umis_min_distance,
     )
-    ch_versions = ch_versions.mix(CORRECTUMIS.out.versions)
 
     // Mix corrected and passthrough BAMs
     ch_unmapped_bam = CORRECTUMIS.out.bam.mix(ch_fastqtobam.passthrough)
@@ -92,7 +90,6 @@ workflow FASTQUORUM {
     // MODULE: Align with bwa mem
     //
     ALIGN_RAW_BAM(ch_unmapped_bam, ch_fasta, ch_fasta_fai, ch_dict, ch_bwa, "template-coordinate")
-    ch_versions = ch_versions.mix(ALIGN_RAW_BAM.out.versions.first())
 
     //
     // Create a channel that:
@@ -130,14 +127,12 @@ workflow FASTQUORUM {
     //
     GROUPREADSBYUMI(bam_all, params.groupreadsbyumi_strategy, params.groupreadsbyumi_edits)
     ch_multiqc_files = ch_multiqc_files.mix(GROUPREADSBYUMI.out.histogram.map { meta_item -> meta_item[1] }.collect())
-    ch_versions = ch_versions.mix(GROUPREADSBYUMI.out.versions.first())
 
     if (params.duplex_seq) {
         //
         // MODULE: Run fgbio CollectDuplexSeqMetrics
         //
         COLLECTDUPLEXSEQMETRICS(GROUPREADSBYUMI.out.bam)
-        ch_versions = ch_versions.mix(COLLECTDUPLEXSEQMETRICS.out.versions.first())
     }
 
     // TODO: duplex_seq can be inferred from the read structure, but that's out of scope for now
@@ -147,7 +142,6 @@ workflow FASTQUORUM {
             // MODULE: Run fgbio CallDuplexConsensusReads
             //
             CALLDDUPLEXCONSENSUSREADS(GROUPREADSBYUMI.out.bam, params.call_min_reads, params.call_min_baseq)
-            ch_versions = ch_versions.mix(CALLDDUPLEXCONSENSUSREADS.out.versions.first())
 
             // Add the consensus BAM to the channel for downstream processing
             CALLDDUPLEXCONSENSUSREADS.out.bam.set { ch_consensus_bam }
@@ -157,7 +151,6 @@ workflow FASTQUORUM {
             // MODULE: Run fgbio CallMolecularConsensusReads
             //
             CALLMOLECULARCONSENSUSREADS(GROUPREADSBYUMI.out.bam, params.call_min_reads, params.call_min_baseq)
-            ch_versions = ch_versions.mix(CALLMOLECULARCONSENSUSREADS.out.versions.first())
 
             // Add the consensus BAM to the channel for downstream processing
             CALLMOLECULARCONSENSUSREADS.out.bam.set { ch_consensus_bam }
@@ -167,13 +160,11 @@ workflow FASTQUORUM {
         // MODULE: Align with bwa mem
         //
         ALIGN_CONSENSUS_BAM(ch_consensus_bam, ch_fasta, ch_fasta_fai, ch_dict, ch_bwa, "none")
-        ch_versions = ch_versions.mix(ALIGN_CONSENSUS_BAM.out.versions.first())
 
         //
         // MODULE: Run fgbio FilterConsensusReads
         //
         FILTERCONSENSUSREADS(ALIGN_CONSENSUS_BAM.out.bam, ch_fasta, params.filter_min_reads, params.filter_min_baseq, params.filter_max_base_error_rate)
-        ch_versions = ch_versions.mix(FILTERCONSENSUSREADS.out.versions.first())
     }
     else {
         if (params.duplex_seq) {
@@ -181,7 +172,6 @@ workflow FASTQUORUM {
             // MODULE: Run fgbio CallDuplexConsensusReads and fgbio FilterConsensusReads
             //
             CALLANDFILTERDUPLEXCONSENSUSREADS(GROUPREADSBYUMI.out.bam, ch_fasta, ch_fasta_fai, params.call_min_reads, params.call_min_baseq, params.filter_max_base_error_rate)
-            ch_versions = ch_versions.mix(CALLANDFILTERDUPLEXCONSENSUSREADS.out.versions.first())
 
             // Add the consensus BAM to the channel for downstream processing
             CALLANDFILTERDUPLEXCONSENSUSREADS.out.bam.set { ch_consensus_bam }
@@ -191,7 +181,6 @@ workflow FASTQUORUM {
             // MODULE: Run fgbio CallMolecularConsensusReads and fgbio FilterConsensusReads
             //
             CALLANDFILTERMOLECULARCONSENSUSREADS(GROUPREADSBYUMI.out.bam, ch_fasta, ch_fasta_fai, params.call_min_reads, params.call_min_baseq, params.filter_max_base_error_rate)
-            ch_versions = ch_versions.mix(CALLANDFILTERMOLECULARCONSENSUSREADS.out.versions.first())
 
             // Add the consensus BAM to the channel for downstream processing
             CALLANDFILTERMOLECULARCONSENSUSREADS.out.bam.set { ch_consensus_bam }
@@ -201,7 +190,6 @@ workflow FASTQUORUM {
         // MODULE: Align with bwa mem
         //
         ALIGN_CONSENSUS_BAM(ch_consensus_bam, ch_fasta, ch_fasta_fai, ch_dict, ch_bwa, "coordinate")
-        ch_versions = ch_versions.mix(ALIGN_CONSENSUS_BAM.out.versions.first())
     }
 
     //

--- a/workflows/fastquorum.nf
+++ b/workflows/fastquorum.nf
@@ -42,7 +42,6 @@ workflow FASTQUORUM {
 
     main:
 
-    ch_versions = channel.empty()
     ch_multiqc_files = channel.empty()
     //
     // MODULE: Run FastQC
@@ -212,7 +211,7 @@ workflow FASTQUORUM {
             "${process}:\n${tool_versions.join('\n')}"
         }
 
-    softwareVersionsToYAML(ch_versions.mix(topic_versions.versions_file))
+    softwareVersionsToYAML(topic_versions.versions_file)
         .mix(topic_versions_string)
         .collectFile(
             storeDir: "${params.outdir}/pipeline_info",
@@ -262,5 +261,4 @@ workflow FASTQUORUM {
 
     emit:
     multiqc_report = MULTIQC.out.report.map { _meta, report -> [report] }.toList() // channel: /path/to/multiqc_report.html
-    versions = ch_versions // channel: [ path(versions.yml) ]
 }


### PR DESCRIPTION
Stacked on #151 (nf-core component updates). This PR updates the **local** modules, split out per review feedback (easier to review in stages).

## Changes
- Migrate all 10 local modules (9 fgbio + align_bam) to **version-topic** emission (`tuple(task.process, tool, eval(cmd)), topic: versions`); remove the obsolete `.out.versions` mixing (and the now-vestigial `ch_versions` scaffold) in the workflow.
- `FILTERCONSENSUSREADS` now also reports the **samtools** version (it pipes into `samtools sort`), matching `ALIGN_BAM`'s multi-tool reporting.
- Add **`environment.yml`** to each local module and reference it via `conda "${moduleDir}/environment.yml"`.
- Add **`meta.yml`** to each local module (name/description/keywords/tools/input/output) with a **`containers:`** block (docker + singularity-`oras://`, amd64 + arm64) built via Seqera Containers for the 3 distinct environments (`fgbio`, `fgbio+samtools`, `bwa+fgbio+samtools`).
- Regenerate `conf/containers_*.config` so the docker + singularity-oras configs include all local processes (https/conda-lock configs keep nf-core modules only — those wave artifacts weren't generated for the local containers).

## Verification (nextflow 25.10.4)
- `nf-core pipelines lint` — 0 failures
- `nf-test test --profile debug,test,docker` — full suite passes. The versions YAML matches pre-migration output except for the newly added `samtools` line under `FILTERCONSENSUSREADS` (snapshots updated accordingly).

> Base this on #151; merge #151 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
